### PR TITLE
add initial Java template documentation

### DIFF
--- a/docs/docs/features/data/helloworld.module.yaml
+++ b/docs/docs/features/data/helloworld.module.yaml
@@ -1,0 +1,29 @@
+schema: apigear.module/1.0
+name: io.world
+version: "1.0.0"
+
+interfaces:
+  - name: Hello
+    properties:
+      - { name: last, type: Message }
+    operations:
+      - name: say
+        params:
+          - { name: msg, type: Message }
+          - { name: when, type: When }
+        return:
+          type: int
+    signals:
+      - name: justSaid
+        params:
+          - { name: msg, type: Message }
+enums:
+  - name: When
+    members:
+      - { name: Now, value: 0 }
+      - { name: Soon, value: 1 }
+      - { name: Never, value: 2 }
+structs:
+  - name: Message
+    fields:
+      - { name: content, type: string }

--- a/docs/docs/features/features.md
+++ b/docs/docs/features/features.md
@@ -1,0 +1,106 @@
+---
+sidebar_position: 2
+sidebar_label: "Features"
+title: "Java Template Features Overview"
+description: "Overview of ApiGear Java template features: API generation with interfaces, enums, structs, and abstract base classes."
+keywords: [java features, api generation, apigear]
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import helloWorldModuleComponent from '!!raw-loader!./data/helloworld.module.yaml';
+
+# Features
+
+This guide explains how to use the generated code, what features are available, and their benefits.
+
+:::info
+A feature is a part of the template that generates a specific aspect of the code. For example, the `api` feature generates the core interfaces and data types.
+:::
+
+## Get started
+
+This template generates Java types from your API definitions. The generated code includes interfaces, abstract base classes, enums, and structs ready to use in any Java project.
+
+:::note
+Basic Java knowledge is required. Familiarity with interfaces, abstract classes, and event listener patterns will help you get the most out of the generated code.
+:::
+
+### Code generation
+
+Follow the documentation for [code generation](/docs/guide/quick-start) in general and [CLI](/docs/cli/generate) or the [Studio](/docs/studio/intro) tools.
+Or try the [quick start guide](../quickstart/index.md) first, which shows how to prepare an API and generate code from it.
+
+:::tip
+For questions regarding this template please go to our [discussions page](https://github.com/orgs/apigear-io/discussions). For feature requests or bug reports please use the [issue tracker](https://github.com/apigear-io/template-java/issues).
+:::
+
+### Example API
+
+The following code snippet contains the _API_ definition which is used throughout this guide to demonstrate the generated code and its usage.
+
+<details>
+    <summary>Hello World API (click to expand)</summary>
+    <CodeBlock language="yaml" showLineNumbers>{helloWorldModuleComponent}</CodeBlock>
+</details>
+
+## Features
+
+### Core Features
+
+Core features generate Java types from your API definition:
+
+- [api](#generated-code-structure) - generates interfaces, event listeners, abstract base classes, enums, and structs
+- `stubs` (planned) - adds basic stubs for the `api`, providing classes that can be instantiated with default behavior
+- `test` (planned) - generates unit test stubs for the API
+- `demo` (planned) - generates a demo application showcasing API usage
+
+Each feature can be selected using the solution file or via the command line tool.
+
+:::note
+_Features are case sensitive, make sure to always **use lower-case.**_
+:::
+
+:::tip
+The _meta_ feature `all` enables all specified features of the template. If you want to see the full extent of the generated code, `all` is the easiest solution.
+Please note, `all` is part of the code generator and not explicitly used within templates.
+:::
+
+## Generated code structure
+
+For the Hello World API, the `api` feature generates a single Java source file containing all types for the module:
+
+- **`When`** enum — maps to the `When` enum defined in the API
+- **`Message`** class — maps to the `Message` struct, fields are annotated with [Jackson](https://github.com/FasterXML/jackson) `@JsonProperty` for JSON serialization
+- **`IHello`** interface — the `Hello` interface with property getters/setters and operations
+- **`IHelloEventListener`** event listener — callback interface for property changes and signals
+- **`AbstractHello`** abstract class — base implementation managing listeners and property change notifications
+
+:::note
+The generated structs use [Jackson](https://github.com/FasterXML/jackson) annotations (`@JsonProperty`) for JSON serialization. If you use JSON serialization in your project, add the Jackson dependency:
+```xml
+<dependency>
+    <groupId>com.fasterxml.jackson.core</groupId>
+    <artifactId>jackson-databind</artifactId>
+    <version>2.17.0</version>
+</dependency>
+```
+:::
+
+## Folder structure
+
+The following diagram shows the folder structure generated for the `api` feature.
+
+```bash
+📂hello-world
+ ┣ 📂apigear
+ ┃ ┣ 📜helloworld.solution.yaml
+ ┃ ┗ 📜helloworld.module.yaml
+ ┣ 📂java_hello_world
+ # highlight-next-line
+ ┃ ┗ 📂io.world.api
+ ┃   ┗ 📜IoWorld.java
+```
+
+:::note
+The module name `io.world` is combined with the feature name to form the package directory `io.world.api`. The source file name `IoWorld.java` is derived from the module name in PascalCase.
+:::

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 0
+sidebar_label: "Introduction"
+title: "Java API Code Generator - ApiGear Template"
+description: "Generate Java interfaces, enums, structs, and abstract base classes from API definitions with the ApiGear code generator."
+keywords: [java, api generator, code generator, apigear, java template]
+---
+
+# Template Java
+
+This is the documentation for the _Java_ template for the [ApiGear](/docs/guide/quick-start) code generator.
+
+It generates Java interfaces, enums, structs, and abstract base classes from your API definitions.
+
+The documentation is split into the following sections:
+
+- [Quick-Start](quickstart/index.md?current-template=template-java) is the easiest way to get started
+- [Features](features/features.md) explains the available code generator features, what code is generated, and how to use it

--- a/docs/docs/quickstart/index.md
+++ b/docs/docs/quickstart/index.md
@@ -1,0 +1,105 @@
+---
+sidebar_position: 1
+sidebar_label: "Quick Start"
+title: "Quick Start: Generate Java Code from API Definitions"
+description: "Step-by-step guide to generate Java interfaces and data types from YAML API definitions using the ApiGear code generator."
+keywords: [java quickstart, api code generation, java interface, apigear tutorial]
+---
+import QuickStartCommon from "@site/docs/_quickstart_common.md"
+
+# Quick-Start
+
+The Quick-Start guide explains how to, in a few steps, get from an API to a functional *Java* project.
+For more general information about first steps with ApiGear, see [First Steps](/docs/guide/quick-start).
+
+The quick start uses only the `api` feature. For all available features, see the [overview](features/features.md).
+
+<QuickStartCommon />
+
+## 5. Use the generated Java project
+
+:::tip Prerequisites
+This guide assumes you have JDK 11 or later installed. See [Oracle JDK](https://www.oracle.com/java/technologies/downloads/) or [Eclipse Adoptium](https://adoptium.net/) for downloads.
+:::
+
+### Project folder structure
+
+For the code generation we assume that both *ApiGear* files reside in an `apigear` subfolder next to the generated files.
+In this case the folder structure should look similar to this.
+```bash
+📂hello-world
+ ┣ 📂apigear
+ ┃ ┣ 📜helloworld.solution.yaml
+ ┃ ┗ 📜helloworld.module.yaml
+ ┣ 📂java_hello_world
+ # highlight-next-line
+ ┃ ┗ 📂io.world.api
+ ┃   ┗ 📜IoWorld.java
+```
+
+The generated package follows the pattern `<module>.api`, here `io.world.api` as the module name (defined in line 2 of `helloworld.module.yaml`).
+The `api` feature generates interfaces, event listeners, abstract base classes, enums, and structs.
+
+### Create and run an example
+
+The generated `IoWorld.java` contains all types for the module: the `When` enum, the `Message` struct, the `IHello` interface, the `IHelloEventListener` event listener, and the `AbstractHello` abstract base class. You can implement the interface and use it in your project:
+
+```java
+import io.world.api.IoWorld.*;
+
+public class HelloExample {
+    // A simple implementation of the Hello interface
+    static class MyHello extends AbstractHello {
+        private Message last;
+
+        @Override
+        public int say(Message msg, When when) {
+            System.out.println("say called: " + msg.content + " (" + when + ")");
+            return 42;
+        }
+
+        @Override
+        public void setLast(Message last) {
+            Message oldValue = this.last;
+            this.last = last;
+            fireLastChanged(oldValue, last);
+        }
+
+        @Override
+        public Message getLast() {
+            return last;
+        }
+    }
+
+    public static void main(String[] args) {
+        MyHello hello = new MyHello();
+
+        // Use a struct
+        Message msg = new Message("Hello World");
+
+        // Call an operation
+        int result = hello.say(msg, When.Now);
+        System.out.println("Result: " + result);
+
+        // Subscribe to property changes and signals
+        hello.addEventListener(new IHelloEventListener() {
+            @Override
+            public void onLastChanged(Message oldValue, Message newValue) {
+                System.out.println("last changed: " + newValue.content);
+            }
+
+            @Override
+            public void onJustSaid(Message msg) {
+                System.out.println("justSaid signal: " + msg.content);
+            }
+        });
+
+        // Set a property (triggers onLastChanged)
+        hello.setLast(msg);
+    }
+}
+```
+
+:::tip
+For more features, check the [features overview](features/features.md).
+:::


### PR DESCRIPTION
Add a documentation foundation for template-java ahead of the Android support release. The structure follows the existing template docs pattern, with intro, quickstart, and features pages, plus an example API YAML.

Content will be expanded on the Android feature branch.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->