### PR TITLE
Connection close

### DIFF
--- a/goldenmaster/counter/counter_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
+++ b/goldenmaster/counter/counter_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/goldenmaster/counter/counter_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
+++ b/goldenmaster/counter/counter_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/goldenmaster/counter/counterjniclient/CounterJniClient.java
+++ b/goldenmaster/counter/counterjniclient/CounterJniClient.java
@@ -6,6 +6,8 @@ import counter.counter_api.ICounterEventListener;
 import counter.counter_api.RemoteOperationException;
 
 import counter.counter_android_client.CounterClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import android.content.Context;
 
 import android.os.Bundle;
@@ -24,6 +26,11 @@ public class CounterJniClient extends AbstractCounter implements ICounterEventLi
 
     private static String ModuleName = "counter.counterjniservice.CounterJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -237,11 +244,25 @@ public class CounterJniClient extends AbstractCounter implements ICounterEventLi
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/counter/counterjniservice/CounterJniServiceStarter.java
+++ b/goldenmaster/counter/counterjniservice/CounterJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import counter.counter_api.ICounterEventListener;
 import counter.counter_api.ICounter;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import counter.counter_android_service.CounterServiceAdapter;
 import counter.counterjniservice.CounterJniServiceProvider;
 import counter.counter_android_service.CounterBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class CounterJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static ICounter start(Context ctx)
     {
-        return IMPL.start(ctx);
+        ICounter result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/customTypes/customTypes_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
+++ b/goldenmaster/customTypes/customTypes_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/goldenmaster/customTypes/customTypes_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
+++ b/goldenmaster/customTypes/customTypes_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/goldenmaster/externTypes/externTypes_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
+++ b/goldenmaster/externTypes/externTypes_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/goldenmaster/externTypes/externTypes_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
+++ b/goldenmaster/externTypes/externTypes_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/goldenmaster/tbEnum/tbEnum_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
+++ b/goldenmaster/tbEnum/tbEnum_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/goldenmaster/tbEnum/tbEnum_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
+++ b/goldenmaster/tbEnum/tbEnum_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/goldenmaster/tbEnum/tbEnumjniclient/EnumInterfaceJniClient.java
+++ b/goldenmaster/tbEnum/tbEnumjniclient/EnumInterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbEnum.tbEnum_api.IEnumInterfaceEventListener;
 import tbEnum.tbEnum_api.RemoteOperationException;
 
 import tbEnum.tbEnum_android_client.EnumInterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbEnum.tbEnum_api.Enum0;
 import tbEnum.tbEnum_android_messenger.Enum0Parcelable;
 import tbEnum.tbEnum_api.Enum1;
@@ -32,6 +34,11 @@ public class EnumInterfaceJniClient extends AbstractEnumInterface implements IEn
 
     private static String ModuleName = "tbEnum.tbEnumjniservice.EnumInterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -245,11 +252,25 @@ public class EnumInterfaceJniClient extends AbstractEnumInterface implements IEn
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbEnum/tbEnumjniservice/EnumInterfaceJniServiceStarter.java
+++ b/goldenmaster/tbEnum/tbEnumjniservice/EnumInterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbEnum.tbEnum_api.IEnumInterfaceEventListener;
 import tbEnum.tbEnum_api.IEnumInterface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbEnum.tbEnum_android_service.EnumInterfaceServiceAdapter;
 import tbEnum.tbEnumjniservice.EnumInterfaceJniServiceProvider;
 import tbEnum.tbEnum_android_service.EnumInterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class EnumInterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static IEnumInterface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        IEnumInterface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbIfaceimport/tbIfaceimport_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
+++ b/goldenmaster/tbIfaceimport/tbIfaceimport_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/goldenmaster/tbIfaceimport/tbIfaceimport_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
+++ b/goldenmaster/tbIfaceimport/tbIfaceimport_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/goldenmaster/tbIfaceimport/tbIfaceimportjniclient/EmptyIfJniClient.java
+++ b/goldenmaster/tbIfaceimport/tbIfaceimportjniclient/EmptyIfJniClient.java
@@ -5,6 +5,8 @@ import tbIfaceimport.tbIfaceimport_api.AbstractEmptyIf;
 import tbIfaceimport.tbIfaceimport_api.IEmptyIfEventListener;
 
 import tbIfaceimport.tbIfaceimport_android_client.EmptyIfClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import android.content.Context;
 
 import android.os.Bundle;
@@ -24,6 +26,11 @@ public class EmptyIfJniClient extends AbstractEmptyIf implements IEmptyIfEventLi
     private static String ModuleName = "tbIfaceimport.tbIfaceimportjniservice.EmptyIfJniService";
     private String lastServicePackage ="";
 
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
+
     @Override
     public boolean _isReady()
     {
@@ -32,11 +39,25 @@ public class EmptyIfJniClient extends AbstractEmptyIf implements IEmptyIfEventLi
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbIfaceimport/tbIfaceimportjniservice/EmptyIfJniServiceStarter.java
+++ b/goldenmaster/tbIfaceimport/tbIfaceimportjniservice/EmptyIfJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbIfaceimport.tbIfaceimport_api.IEmptyIfEventListener;
 import tbIfaceimport.tbIfaceimport_api.IEmptyIf;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbIfaceimport.tbIfaceimport_android_service.EmptyIfServiceAdapter;
 import tbIfaceimport.tbIfaceimportjniservice.EmptyIfJniServiceProvider;
 import tbIfaceimport.tbIfaceimport_android_service.EmptyIfBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class EmptyIfJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static IEmptyIf start(Context ctx)
     {
-        return IMPL.start(ctx);
+        IEmptyIf result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbNames/tbNames_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
+++ b/goldenmaster/tbNames/tbNames_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/goldenmaster/tbNames/tbNames_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
+++ b/goldenmaster/tbNames/tbNames_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/goldenmaster/tbNames/tbNamesjniclient/NamEsJniClient.java
+++ b/goldenmaster/tbNames/tbNamesjniclient/NamEsJniClient.java
@@ -6,6 +6,8 @@ import tbNames.tbNames_api.INamEsEventListener;
 import tbNames.tbNames_api.RemoteOperationException;
 
 import tbNames.tbNames_android_client.NamEsClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbNames.tbNames_api.EnumWithUnderScores;
 import tbNames.tbNames_android_messenger.EnumWithUnderScoresParcelable;
 import android.content.Context;
@@ -26,6 +28,11 @@ public class NamEsJniClient extends AbstractNamEs implements INamEsEventListener
 
     private static String ModuleName = "tbNames.tbNamesjniservice.NamEsJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -163,11 +170,25 @@ public class NamEsJniClient extends AbstractNamEs implements INamEsEventListener
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbNames/tbNamesjniservice/NamEsJniServiceStarter.java
+++ b/goldenmaster/tbNames/tbNamesjniservice/NamEsJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbNames.tbNames_api.INamEsEventListener;
 import tbNames.tbNames_api.INamEs;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbNames.tbNames_android_service.NamEsServiceAdapter;
 import tbNames.tbNamesjniservice.NamEsJniServiceProvider;
 import tbNames.tbNames_android_service.NamEsBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class NamEsJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static INamEs start(Context ctx)
     {
-        return IMPL.start(ctx);
+        INamEs result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbRefIfaces/tbRefIfaces_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
+++ b/goldenmaster/tbRefIfaces/tbRefIfaces_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/goldenmaster/tbRefIfaces/tbRefIfaces_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
+++ b/goldenmaster/tbRefIfaces/tbRefIfaces_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/goldenmaster/tbRefIfaces/tbRefIfacesjniclient/ParentIfJniClient.java
+++ b/goldenmaster/tbRefIfaces/tbRefIfacesjniclient/ParentIfJniClient.java
@@ -6,6 +6,8 @@ import tbRefIfaces.tbRefIfaces_api.IParentIfEventListener;
 import tbRefIfaces.tbRefIfaces_api.RemoteOperationException;
 
 import tbRefIfaces.tbRefIfaces_android_client.ParentIfClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbRefIfaces.tbRefIfaces_api.ISimpleLocalIf;
 import tbRefIfaces.tbRefIfaces_android_messenger.SimpleLocalIfParcelable;
 import android.content.Context;
@@ -26,6 +28,11 @@ public class ParentIfJniClient extends AbstractParentIf implements IParentIfEven
 
     private static String ModuleName = "tbRefIfaces.tbRefIfacesjniservice.ParentIfJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -239,11 +246,25 @@ public class ParentIfJniClient extends AbstractParentIf implements IParentIfEven
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbRefIfaces/tbRefIfacesjniclient/SimpleLocalIfJniClient.java
+++ b/goldenmaster/tbRefIfaces/tbRefIfacesjniclient/SimpleLocalIfJniClient.java
@@ -6,6 +6,8 @@ import tbRefIfaces.tbRefIfaces_api.ISimpleLocalIfEventListener;
 import tbRefIfaces.tbRefIfaces_api.RemoteOperationException;
 
 import tbRefIfaces.tbRefIfaces_android_client.SimpleLocalIfClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import android.content.Context;
 
 import android.os.Bundle;
@@ -24,6 +26,11 @@ public class SimpleLocalIfJniClient extends AbstractSimpleLocalIf implements ISi
 
     private static String ModuleName = "tbRefIfaces.tbRefIfacesjniservice.SimpleLocalIfJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -84,11 +91,25 @@ public class SimpleLocalIfJniClient extends AbstractSimpleLocalIf implements ISi
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbRefIfaces/tbRefIfacesjniservice/ParentIfJniServiceStarter.java
+++ b/goldenmaster/tbRefIfaces/tbRefIfacesjniservice/ParentIfJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbRefIfaces.tbRefIfaces_api.IParentIfEventListener;
 import tbRefIfaces.tbRefIfaces_api.IParentIf;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbRefIfaces.tbRefIfaces_android_service.ParentIfServiceAdapter;
 import tbRefIfaces.tbRefIfacesjniservice.ParentIfJniServiceProvider;
 import tbRefIfaces.tbRefIfaces_android_service.ParentIfBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class ParentIfJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static IParentIf start(Context ctx)
     {
-        return IMPL.start(ctx);
+        IParentIf result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbRefIfaces/tbRefIfacesjniservice/SimpleLocalIfJniServiceStarter.java
+++ b/goldenmaster/tbRefIfaces/tbRefIfacesjniservice/SimpleLocalIfJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbRefIfaces.tbRefIfaces_api.ISimpleLocalIfEventListener;
 import tbRefIfaces.tbRefIfaces_api.ISimpleLocalIf;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbRefIfaces.tbRefIfaces_android_service.SimpleLocalIfServiceAdapter;
 import tbRefIfaces.tbRefIfacesjniservice.SimpleLocalIfJniServiceProvider;
 import tbRefIfaces.tbRefIfaces_android_service.SimpleLocalIfBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class SimpleLocalIfJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static ISimpleLocalIf start(Context ctx)
     {
-        return IMPL.start(ctx);
+        ISimpleLocalIf result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSame1/tbSame1_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
+++ b/goldenmaster/tbSame1/tbSame1_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/goldenmaster/tbSame1/tbSame1_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
+++ b/goldenmaster/tbSame1/tbSame1_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/goldenmaster/tbSame1/tbSame1jniclient/SameEnum1InterfaceJniClient.java
+++ b/goldenmaster/tbSame1/tbSame1jniclient/SameEnum1InterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSame1.tbSame1_api.ISameEnum1InterfaceEventListener;
 import tbSame1.tbSame1_api.RemoteOperationException;
 
 import tbSame1.tbSame1_android_client.SameEnum1InterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame1.tbSame1_api.Enum1;
 import tbSame1.tbSame1_android_messenger.Enum1Parcelable;
 import android.content.Context;
@@ -26,6 +28,11 @@ public class SameEnum1InterfaceJniClient extends AbstractSameEnum1Interface impl
 
     private static String ModuleName = "tbSame1.tbSame1jniservice.SameEnum1InterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -86,11 +93,25 @@ public class SameEnum1InterfaceJniClient extends AbstractSameEnum1Interface impl
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSame1/tbSame1jniclient/SameEnum2InterfaceJniClient.java
+++ b/goldenmaster/tbSame1/tbSame1jniclient/SameEnum2InterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSame1.tbSame1_api.ISameEnum2InterfaceEventListener;
 import tbSame1.tbSame1_api.RemoteOperationException;
 
 import tbSame1.tbSame1_android_client.SameEnum2InterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame1.tbSame1_api.Enum1;
 import tbSame1.tbSame1_android_messenger.Enum1Parcelable;
 import tbSame1.tbSame1_api.Enum2;
@@ -28,6 +30,11 @@ public class SameEnum2InterfaceJniClient extends AbstractSameEnum2Interface impl
 
     private static String ModuleName = "tbSame1.tbSame1jniservice.SameEnum2InterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -139,11 +146,25 @@ public class SameEnum2InterfaceJniClient extends AbstractSameEnum2Interface impl
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSame1/tbSame1jniclient/SameStruct1InterfaceJniClient.java
+++ b/goldenmaster/tbSame1/tbSame1jniclient/SameStruct1InterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSame1.tbSame1_api.ISameStruct1InterfaceEventListener;
 import tbSame1.tbSame1_api.RemoteOperationException;
 
 import tbSame1.tbSame1_android_client.SameStruct1InterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame1.tbSame1_api.Struct1;
 import tbSame1.tbSame1_android_messenger.Struct1Parcelable;
 import android.content.Context;
@@ -26,6 +28,11 @@ public class SameStruct1InterfaceJniClient extends AbstractSameStruct1Interface 
 
     private static String ModuleName = "tbSame1.tbSame1jniservice.SameStruct1InterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -86,11 +93,25 @@ public class SameStruct1InterfaceJniClient extends AbstractSameStruct1Interface 
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSame1/tbSame1jniclient/SameStruct2InterfaceJniClient.java
+++ b/goldenmaster/tbSame1/tbSame1jniclient/SameStruct2InterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSame1.tbSame1_api.ISameStruct2InterfaceEventListener;
 import tbSame1.tbSame1_api.RemoteOperationException;
 
 import tbSame1.tbSame1_android_client.SameStruct2InterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame1.tbSame1_api.Struct1;
 import tbSame1.tbSame1_android_messenger.Struct1Parcelable;
 import tbSame1.tbSame1_api.Struct2;
@@ -28,6 +30,11 @@ public class SameStruct2InterfaceJniClient extends AbstractSameStruct2Interface 
 
     private static String ModuleName = "tbSame1.tbSame1jniservice.SameStruct2InterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -139,11 +146,25 @@ public class SameStruct2InterfaceJniClient extends AbstractSameStruct2Interface 
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSame1/tbSame1jniservice/SameEnum1InterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSame1/tbSame1jniservice/SameEnum1InterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSame1.tbSame1_api.ISameEnum1InterfaceEventListener;
 import tbSame1.tbSame1_api.ISameEnum1Interface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame1.tbSame1_android_service.SameEnum1InterfaceServiceAdapter;
 import tbSame1.tbSame1jniservice.SameEnum1InterfaceJniServiceProvider;
 import tbSame1.tbSame1_android_service.SameEnum1InterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class SameEnum1InterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static ISameEnum1Interface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        ISameEnum1Interface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSame1/tbSame1jniservice/SameEnum2InterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSame1/tbSame1jniservice/SameEnum2InterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSame1.tbSame1_api.ISameEnum2InterfaceEventListener;
 import tbSame1.tbSame1_api.ISameEnum2Interface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame1.tbSame1_android_service.SameEnum2InterfaceServiceAdapter;
 import tbSame1.tbSame1jniservice.SameEnum2InterfaceJniServiceProvider;
 import tbSame1.tbSame1_android_service.SameEnum2InterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class SameEnum2InterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static ISameEnum2Interface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        ISameEnum2Interface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSame1/tbSame1jniservice/SameStruct1InterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSame1/tbSame1jniservice/SameStruct1InterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSame1.tbSame1_api.ISameStruct1InterfaceEventListener;
 import tbSame1.tbSame1_api.ISameStruct1Interface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame1.tbSame1_android_service.SameStruct1InterfaceServiceAdapter;
 import tbSame1.tbSame1jniservice.SameStruct1InterfaceJniServiceProvider;
 import tbSame1.tbSame1_android_service.SameStruct1InterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class SameStruct1InterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static ISameStruct1Interface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        ISameStruct1Interface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSame1/tbSame1jniservice/SameStruct2InterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSame1/tbSame1jniservice/SameStruct2InterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSame1.tbSame1_api.ISameStruct2InterfaceEventListener;
 import tbSame1.tbSame1_api.ISameStruct2Interface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame1.tbSame1_android_service.SameStruct2InterfaceServiceAdapter;
 import tbSame1.tbSame1jniservice.SameStruct2InterfaceJniServiceProvider;
 import tbSame1.tbSame1_android_service.SameStruct2InterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class SameStruct2InterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static ISameStruct2Interface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        ISameStruct2Interface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSame2/tbSame2_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
+++ b/goldenmaster/tbSame2/tbSame2_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/goldenmaster/tbSame2/tbSame2_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
+++ b/goldenmaster/tbSame2/tbSame2_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/goldenmaster/tbSame2/tbSame2jniclient/SameEnum1InterfaceJniClient.java
+++ b/goldenmaster/tbSame2/tbSame2jniclient/SameEnum1InterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSame2.tbSame2_api.ISameEnum1InterfaceEventListener;
 import tbSame2.tbSame2_api.RemoteOperationException;
 
 import tbSame2.tbSame2_android_client.SameEnum1InterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame2.tbSame2_api.Enum1;
 import tbSame2.tbSame2_android_messenger.Enum1Parcelable;
 import android.content.Context;
@@ -26,6 +28,11 @@ public class SameEnum1InterfaceJniClient extends AbstractSameEnum1Interface impl
 
     private static String ModuleName = "tbSame2.tbSame2jniservice.SameEnum1InterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -86,11 +93,25 @@ public class SameEnum1InterfaceJniClient extends AbstractSameEnum1Interface impl
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSame2/tbSame2jniclient/SameEnum2InterfaceJniClient.java
+++ b/goldenmaster/tbSame2/tbSame2jniclient/SameEnum2InterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSame2.tbSame2_api.ISameEnum2InterfaceEventListener;
 import tbSame2.tbSame2_api.RemoteOperationException;
 
 import tbSame2.tbSame2_android_client.SameEnum2InterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame2.tbSame2_api.Enum1;
 import tbSame2.tbSame2_android_messenger.Enum1Parcelable;
 import tbSame2.tbSame2_api.Enum2;
@@ -28,6 +30,11 @@ public class SameEnum2InterfaceJniClient extends AbstractSameEnum2Interface impl
 
     private static String ModuleName = "tbSame2.tbSame2jniservice.SameEnum2InterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -139,11 +146,25 @@ public class SameEnum2InterfaceJniClient extends AbstractSameEnum2Interface impl
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSame2/tbSame2jniclient/SameStruct1InterfaceJniClient.java
+++ b/goldenmaster/tbSame2/tbSame2jniclient/SameStruct1InterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSame2.tbSame2_api.ISameStruct1InterfaceEventListener;
 import tbSame2.tbSame2_api.RemoteOperationException;
 
 import tbSame2.tbSame2_android_client.SameStruct1InterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame2.tbSame2_api.Struct1;
 import tbSame2.tbSame2_android_messenger.Struct1Parcelable;
 import android.content.Context;
@@ -26,6 +28,11 @@ public class SameStruct1InterfaceJniClient extends AbstractSameStruct1Interface 
 
     private static String ModuleName = "tbSame2.tbSame2jniservice.SameStruct1InterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -86,11 +93,25 @@ public class SameStruct1InterfaceJniClient extends AbstractSameStruct1Interface 
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSame2/tbSame2jniclient/SameStruct2InterfaceJniClient.java
+++ b/goldenmaster/tbSame2/tbSame2jniclient/SameStruct2InterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSame2.tbSame2_api.ISameStruct2InterfaceEventListener;
 import tbSame2.tbSame2_api.RemoteOperationException;
 
 import tbSame2.tbSame2_android_client.SameStruct2InterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame2.tbSame2_api.Struct1;
 import tbSame2.tbSame2_android_messenger.Struct1Parcelable;
 import tbSame2.tbSame2_api.Struct2;
@@ -28,6 +30,11 @@ public class SameStruct2InterfaceJniClient extends AbstractSameStruct2Interface 
 
     private static String ModuleName = "tbSame2.tbSame2jniservice.SameStruct2InterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -139,11 +146,25 @@ public class SameStruct2InterfaceJniClient extends AbstractSameStruct2Interface 
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSame2/tbSame2jniservice/SameEnum1InterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSame2/tbSame2jniservice/SameEnum1InterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSame2.tbSame2_api.ISameEnum1InterfaceEventListener;
 import tbSame2.tbSame2_api.ISameEnum1Interface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame2.tbSame2_android_service.SameEnum1InterfaceServiceAdapter;
 import tbSame2.tbSame2jniservice.SameEnum1InterfaceJniServiceProvider;
 import tbSame2.tbSame2_android_service.SameEnum1InterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class SameEnum1InterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static ISameEnum1Interface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        ISameEnum1Interface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSame2/tbSame2jniservice/SameEnum2InterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSame2/tbSame2jniservice/SameEnum2InterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSame2.tbSame2_api.ISameEnum2InterfaceEventListener;
 import tbSame2.tbSame2_api.ISameEnum2Interface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame2.tbSame2_android_service.SameEnum2InterfaceServiceAdapter;
 import tbSame2.tbSame2jniservice.SameEnum2InterfaceJniServiceProvider;
 import tbSame2.tbSame2_android_service.SameEnum2InterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class SameEnum2InterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static ISameEnum2Interface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        ISameEnum2Interface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSame2/tbSame2jniservice/SameStruct1InterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSame2/tbSame2jniservice/SameStruct1InterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSame2.tbSame2_api.ISameStruct1InterfaceEventListener;
 import tbSame2.tbSame2_api.ISameStruct1Interface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame2.tbSame2_android_service.SameStruct1InterfaceServiceAdapter;
 import tbSame2.tbSame2jniservice.SameStruct1InterfaceJniServiceProvider;
 import tbSame2.tbSame2_android_service.SameStruct1InterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class SameStruct1InterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static ISameStruct1Interface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        ISameStruct1Interface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSame2/tbSame2jniservice/SameStruct2InterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSame2/tbSame2jniservice/SameStruct2InterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSame2.tbSame2_api.ISameStruct2InterfaceEventListener;
 import tbSame2.tbSame2_api.ISameStruct2Interface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSame2.tbSame2_android_service.SameStruct2InterfaceServiceAdapter;
 import tbSame2.tbSame2jniservice.SameStruct2InterfaceJniServiceProvider;
 import tbSame2.tbSame2_android_service.SameStruct2InterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class SameStruct2InterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static ISameStruct2Interface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        ISameStruct2Interface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSimple/tbSimple_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
+++ b/goldenmaster/tbSimple/tbSimple_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/goldenmaster/tbSimple/tbSimple_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
+++ b/goldenmaster/tbSimple/tbSimple_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/goldenmaster/tbSimple/tbSimplejniclient/EmptyInterfaceJniClient.java
+++ b/goldenmaster/tbSimple/tbSimplejniclient/EmptyInterfaceJniClient.java
@@ -5,6 +5,8 @@ import tbSimple.tbSimple_api.AbstractEmptyInterface;
 import tbSimple.tbSimple_api.IEmptyInterfaceEventListener;
 
 import tbSimple.tbSimple_android_client.EmptyInterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import android.content.Context;
 
 import android.os.Bundle;
@@ -24,6 +26,11 @@ public class EmptyInterfaceJniClient extends AbstractEmptyInterface implements I
     private static String ModuleName = "tbSimple.tbSimplejniservice.EmptyInterfaceJniService";
     private String lastServicePackage ="";
 
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
+
     @Override
     public boolean _isReady()
     {
@@ -32,11 +39,25 @@ public class EmptyInterfaceJniClient extends AbstractEmptyInterface implements I
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSimple/tbSimplejniclient/NoOperationsInterfaceJniClient.java
+++ b/goldenmaster/tbSimple/tbSimplejniclient/NoOperationsInterfaceJniClient.java
@@ -5,6 +5,8 @@ import tbSimple.tbSimple_api.AbstractNoOperationsInterface;
 import tbSimple.tbSimple_api.INoOperationsInterfaceEventListener;
 
 import tbSimple.tbSimple_android_client.NoOperationsInterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import android.content.Context;
 
 import android.os.Bundle;
@@ -23,6 +25,11 @@ public class NoOperationsInterfaceJniClient extends AbstractNoOperationsInterfac
 
     private static String ModuleName = "tbSimple.tbSimplejniservice.NoOperationsInterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -58,11 +65,25 @@ public class NoOperationsInterfaceJniClient extends AbstractNoOperationsInterfac
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSimple/tbSimplejniclient/NoPropertiesInterfaceJniClient.java
+++ b/goldenmaster/tbSimple/tbSimplejniclient/NoPropertiesInterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSimple.tbSimple_api.INoPropertiesInterfaceEventListener;
 import tbSimple.tbSimple_api.RemoteOperationException;
 
 import tbSimple.tbSimple_android_client.NoPropertiesInterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import android.content.Context;
 
 import android.os.Bundle;
@@ -24,6 +26,11 @@ public class NoPropertiesInterfaceJniClient extends AbstractNoPropertiesInterfac
 
     private static String ModuleName = "tbSimple.tbSimplejniservice.NoPropertiesInterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -109,11 +116,25 @@ public class NoPropertiesInterfaceJniClient extends AbstractNoPropertiesInterfac
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSimple/tbSimplejniclient/NoSignalsInterfaceJniClient.java
+++ b/goldenmaster/tbSimple/tbSimplejniclient/NoSignalsInterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSimple.tbSimple_api.INoSignalsInterfaceEventListener;
 import tbSimple.tbSimple_api.RemoteOperationException;
 
 import tbSimple.tbSimple_android_client.NoSignalsInterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import android.content.Context;
 
 import android.os.Bundle;
@@ -24,6 +26,11 @@ public class NoSignalsInterfaceJniClient extends AbstractNoSignalsInterface impl
 
     private static String ModuleName = "tbSimple.tbSimplejniservice.NoSignalsInterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -135,11 +142,25 @@ public class NoSignalsInterfaceJniClient extends AbstractNoSignalsInterface impl
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSimple/tbSimplejniclient/SimpleArrayInterfaceJniClient.java
+++ b/goldenmaster/tbSimple/tbSimplejniclient/SimpleArrayInterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSimple.tbSimple_api.ISimpleArrayInterfaceEventListener;
 import tbSimple.tbSimple_api.RemoteOperationException;
 
 import tbSimple.tbSimple_android_client.SimpleArrayInterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import android.content.Context;
 
 import android.os.Bundle;
@@ -24,6 +26,11 @@ public class SimpleArrayInterfaceJniClient extends AbstractSimpleArrayInterface 
 
     private static String ModuleName = "tbSimple.tbSimplejniservice.SimpleArrayInterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -454,11 +461,25 @@ public class SimpleArrayInterfaceJniClient extends AbstractSimpleArrayInterface 
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSimple/tbSimplejniclient/SimpleInterfaceJniClient.java
+++ b/goldenmaster/tbSimple/tbSimplejniclient/SimpleInterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSimple.tbSimple_api.ISimpleInterfaceEventListener;
 import tbSimple.tbSimple_api.RemoteOperationException;
 
 import tbSimple.tbSimple_android_client.SimpleInterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import android.content.Context;
 
 import android.os.Bundle;
@@ -24,6 +26,11 @@ public class SimpleInterfaceJniClient extends AbstractSimpleInterface implements
 
     private static String ModuleName = "tbSimple.tbSimplejniservice.SimpleInterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -517,11 +524,25 @@ public class SimpleInterfaceJniClient extends AbstractSimpleInterface implements
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSimple/tbSimplejniclient/VoidInterfaceJniClient.java
+++ b/goldenmaster/tbSimple/tbSimplejniclient/VoidInterfaceJniClient.java
@@ -6,6 +6,8 @@ import tbSimple.tbSimple_api.IVoidInterfaceEventListener;
 import tbSimple.tbSimple_api.RemoteOperationException;
 
 import tbSimple.tbSimple_android_client.VoidInterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import android.content.Context;
 
 import android.os.Bundle;
@@ -24,6 +26,11 @@ public class VoidInterfaceJniClient extends AbstractVoidInterface implements IVo
 
     private static String ModuleName = "tbSimple.tbSimplejniservice.VoidInterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -71,11 +78,25 @@ public class VoidInterfaceJniClient extends AbstractVoidInterface implements IVo
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/tbSimple/tbSimplejniservice/EmptyInterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSimple/tbSimplejniservice/EmptyInterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSimple.tbSimple_api.IEmptyInterfaceEventListener;
 import tbSimple.tbSimple_api.IEmptyInterface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSimple.tbSimple_android_service.EmptyInterfaceServiceAdapter;
 import tbSimple.tbSimplejniservice.EmptyInterfaceJniServiceProvider;
 import tbSimple.tbSimple_android_service.EmptyInterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class EmptyInterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static IEmptyInterface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        IEmptyInterface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSimple/tbSimplejniservice/NoOperationsInterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSimple/tbSimplejniservice/NoOperationsInterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSimple.tbSimple_api.INoOperationsInterfaceEventListener;
 import tbSimple.tbSimple_api.INoOperationsInterface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSimple.tbSimple_android_service.NoOperationsInterfaceServiceAdapter;
 import tbSimple.tbSimplejniservice.NoOperationsInterfaceJniServiceProvider;
 import tbSimple.tbSimple_android_service.NoOperationsInterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class NoOperationsInterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static INoOperationsInterface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        INoOperationsInterface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSimple/tbSimplejniservice/NoPropertiesInterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSimple/tbSimplejniservice/NoPropertiesInterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSimple.tbSimple_api.INoPropertiesInterfaceEventListener;
 import tbSimple.tbSimple_api.INoPropertiesInterface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSimple.tbSimple_android_service.NoPropertiesInterfaceServiceAdapter;
 import tbSimple.tbSimplejniservice.NoPropertiesInterfaceJniServiceProvider;
 import tbSimple.tbSimple_android_service.NoPropertiesInterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class NoPropertiesInterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static INoPropertiesInterface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        INoPropertiesInterface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSimple/tbSimplejniservice/NoSignalsInterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSimple/tbSimplejniservice/NoSignalsInterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSimple.tbSimple_api.INoSignalsInterfaceEventListener;
 import tbSimple.tbSimple_api.INoSignalsInterface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSimple.tbSimple_android_service.NoSignalsInterfaceServiceAdapter;
 import tbSimple.tbSimplejniservice.NoSignalsInterfaceJniServiceProvider;
 import tbSimple.tbSimple_android_service.NoSignalsInterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class NoSignalsInterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static INoSignalsInterface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        INoSignalsInterface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSimple/tbSimplejniservice/SimpleArrayInterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSimple/tbSimplejniservice/SimpleArrayInterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSimple.tbSimple_api.ISimpleArrayInterfaceEventListener;
 import tbSimple.tbSimple_api.ISimpleArrayInterface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSimple.tbSimple_android_service.SimpleArrayInterfaceServiceAdapter;
 import tbSimple.tbSimplejniservice.SimpleArrayInterfaceJniServiceProvider;
 import tbSimple.tbSimple_android_service.SimpleArrayInterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class SimpleArrayInterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static ISimpleArrayInterface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        ISimpleArrayInterface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSimple/tbSimplejniservice/SimpleInterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSimple/tbSimplejniservice/SimpleInterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSimple.tbSimple_api.ISimpleInterfaceEventListener;
 import tbSimple.tbSimple_api.ISimpleInterface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSimple.tbSimple_android_service.SimpleInterfaceServiceAdapter;
 import tbSimple.tbSimplejniservice.SimpleInterfaceJniServiceProvider;
 import tbSimple.tbSimple_android_service.SimpleInterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class SimpleInterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static ISimpleInterface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        ISimpleInterface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/tbSimple/tbSimplejniservice/VoidInterfaceJniServiceStarter.java
+++ b/goldenmaster/tbSimple/tbSimplejniservice/VoidInterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import tbSimple.tbSimple_api.IVoidInterfaceEventListener;
 import tbSimple.tbSimple_api.IVoidInterface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import tbSimple.tbSimple_android_service.VoidInterfaceServiceAdapter;
 import tbSimple.tbSimplejniservice.VoidInterfaceJniServiceProvider;
 import tbSimple.tbSimple_android_service.VoidInterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class VoidInterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static IVoidInterface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        IVoidInterface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/testbed1/testbed1_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
+++ b/goldenmaster/testbed1/testbed1_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/goldenmaster/testbed1/testbed1_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
+++ b/goldenmaster/testbed1/testbed1_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/goldenmaster/testbed1/testbed1jniclient/StructArray2InterfaceJniClient.java
+++ b/goldenmaster/testbed1/testbed1jniclient/StructArray2InterfaceJniClient.java
@@ -6,6 +6,8 @@ import testbed1.testbed1_api.IStructArray2InterfaceEventListener;
 import testbed1.testbed1_api.RemoteOperationException;
 
 import testbed1.testbed1_android_client.StructArray2InterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed1.testbed1_api.Enum0;
 import testbed1.testbed1_android_messenger.Enum0Parcelable;
 import testbed1.testbed1_api.StructBool;
@@ -44,6 +46,11 @@ public class StructArray2InterfaceJniClient extends AbstractStructArray2Interfac
 
     private static String ModuleName = "testbed1.testbed1jniservice.StructArray2InterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -308,11 +315,25 @@ public class StructArray2InterfaceJniClient extends AbstractStructArray2Interfac
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/testbed1/testbed1jniclient/StructArrayInterfaceJniClient.java
+++ b/goldenmaster/testbed1/testbed1jniclient/StructArrayInterfaceJniClient.java
@@ -6,6 +6,8 @@ import testbed1.testbed1_api.IStructArrayInterfaceEventListener;
 import testbed1.testbed1_api.RemoteOperationException;
 
 import testbed1.testbed1_android_client.StructArrayInterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed1.testbed1_api.Enum0;
 import testbed1.testbed1_android_messenger.Enum0Parcelable;
 import testbed1.testbed1_api.StructBool;
@@ -34,6 +36,11 @@ public class StructArrayInterfaceJniClient extends AbstractStructArrayInterface 
 
     private static String ModuleName = "testbed1.testbed1jniservice.StructArrayInterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -298,11 +305,25 @@ public class StructArrayInterfaceJniClient extends AbstractStructArrayInterface 
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/testbed1/testbed1jniclient/StructInterfaceJniClient.java
+++ b/goldenmaster/testbed1/testbed1jniclient/StructInterfaceJniClient.java
@@ -6,6 +6,8 @@ import testbed1.testbed1_api.IStructInterfaceEventListener;
 import testbed1.testbed1_api.RemoteOperationException;
 
 import testbed1.testbed1_android_client.StructInterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed1.testbed1_api.StructBool;
 import testbed1.testbed1_android_messenger.StructBoolParcelable;
 import testbed1.testbed1_api.StructFloat;
@@ -32,6 +34,11 @@ public class StructInterfaceJniClient extends AbstractStructInterface implements
 
     private static String ModuleName = "testbed1.testbed1jniservice.StructInterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -245,11 +252,25 @@ public class StructInterfaceJniClient extends AbstractStructInterface implements
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/testbed1/testbed1jniservice/StructArray2InterfaceJniServiceStarter.java
+++ b/goldenmaster/testbed1/testbed1jniservice/StructArray2InterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import testbed1.testbed1_api.IStructArray2InterfaceEventListener;
 import testbed1.testbed1_api.IStructArray2Interface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed1.testbed1_android_service.StructArray2InterfaceServiceAdapter;
 import testbed1.testbed1jniservice.StructArray2InterfaceJniServiceProvider;
 import testbed1.testbed1_android_service.StructArray2InterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class StructArray2InterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static IStructArray2Interface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        IStructArray2Interface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/testbed1/testbed1jniservice/StructArrayInterfaceJniServiceStarter.java
+++ b/goldenmaster/testbed1/testbed1jniservice/StructArrayInterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import testbed1.testbed1_api.IStructArrayInterfaceEventListener;
 import testbed1.testbed1_api.IStructArrayInterface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed1.testbed1_android_service.StructArrayInterfaceServiceAdapter;
 import testbed1.testbed1jniservice.StructArrayInterfaceJniServiceProvider;
 import testbed1.testbed1_android_service.StructArrayInterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class StructArrayInterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static IStructArrayInterface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        IStructArrayInterface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/testbed1/testbed1jniservice/StructInterfaceJniServiceStarter.java
+++ b/goldenmaster/testbed1/testbed1jniservice/StructInterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import testbed1.testbed1_api.IStructInterfaceEventListener;
 import testbed1.testbed1_api.IStructInterface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed1.testbed1_android_service.StructInterfaceServiceAdapter;
 import testbed1.testbed1jniservice.StructInterfaceJniServiceProvider;
 import testbed1.testbed1_android_service.StructInterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class StructInterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static IStructInterface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        IStructInterface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/testbed2/testbed2_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
+++ b/goldenmaster/testbed2/testbed2_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/goldenmaster/testbed2/testbed2_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
+++ b/goldenmaster/testbed2/testbed2_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/goldenmaster/testbed2/testbed2jniclient/ManyParamInterfaceJniClient.java
+++ b/goldenmaster/testbed2/testbed2jniclient/ManyParamInterfaceJniClient.java
@@ -6,6 +6,8 @@ import testbed2.testbed2_api.IManyParamInterfaceEventListener;
 import testbed2.testbed2_api.RemoteOperationException;
 
 import testbed2.testbed2_android_client.ManyParamInterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import android.content.Context;
 
 import android.os.Bundle;
@@ -24,6 +26,11 @@ public class ManyParamInterfaceJniClient extends AbstractManyParamInterface impl
 
     private static String ModuleName = "testbed2.testbed2jniservice.ManyParamInterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -237,11 +244,25 @@ public class ManyParamInterfaceJniClient extends AbstractManyParamInterface impl
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/testbed2/testbed2jniclient/NestedStruct1InterfaceJniClient.java
+++ b/goldenmaster/testbed2/testbed2jniclient/NestedStruct1InterfaceJniClient.java
@@ -6,6 +6,8 @@ import testbed2.testbed2_api.INestedStruct1InterfaceEventListener;
 import testbed2.testbed2_api.RemoteOperationException;
 
 import testbed2.testbed2_android_client.NestedStruct1InterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed2.testbed2_api.NestedStruct1;
 import testbed2.testbed2_android_messenger.NestedStruct1Parcelable;
 import android.content.Context;
@@ -26,6 +28,11 @@ public class NestedStruct1InterfaceJniClient extends AbstractNestedStruct1Interf
 
     private static String ModuleName = "testbed2.testbed2jniservice.NestedStruct1InterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -162,11 +169,25 @@ public class NestedStruct1InterfaceJniClient extends AbstractNestedStruct1Interf
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/testbed2/testbed2jniclient/NestedStruct2InterfaceJniClient.java
+++ b/goldenmaster/testbed2/testbed2jniclient/NestedStruct2InterfaceJniClient.java
@@ -6,6 +6,8 @@ import testbed2.testbed2_api.INestedStruct2InterfaceEventListener;
 import testbed2.testbed2_api.RemoteOperationException;
 
 import testbed2.testbed2_android_client.NestedStruct2InterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed2.testbed2_api.NestedStruct1;
 import testbed2.testbed2_android_messenger.NestedStruct1Parcelable;
 import testbed2.testbed2_api.NestedStruct2;
@@ -28,6 +30,11 @@ public class NestedStruct2InterfaceJniClient extends AbstractNestedStruct2Interf
 
     private static String ModuleName = "testbed2.testbed2jniservice.NestedStruct2InterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -139,11 +146,25 @@ public class NestedStruct2InterfaceJniClient extends AbstractNestedStruct2Interf
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/testbed2/testbed2jniclient/NestedStruct3InterfaceJniClient.java
+++ b/goldenmaster/testbed2/testbed2jniclient/NestedStruct3InterfaceJniClient.java
@@ -6,6 +6,8 @@ import testbed2.testbed2_api.INestedStruct3InterfaceEventListener;
 import testbed2.testbed2_api.RemoteOperationException;
 
 import testbed2.testbed2_android_client.NestedStruct3InterfaceClient;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed2.testbed2_api.NestedStruct1;
 import testbed2.testbed2_android_messenger.NestedStruct1Parcelable;
 import testbed2.testbed2_api.NestedStruct2;
@@ -30,6 +32,11 @@ public class NestedStruct3InterfaceJniClient extends AbstractNestedStruct3Interf
 
     private static String ModuleName = "testbed2.testbed2jniservice.NestedStruct3InterfaceJniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -192,11 +199,25 @@ public class NestedStruct3InterfaceJniClient extends AbstractNestedStruct3Interf
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/goldenmaster/testbed2/testbed2jniservice/ManyParamInterfaceJniServiceStarter.java
+++ b/goldenmaster/testbed2/testbed2jniservice/ManyParamInterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import testbed2.testbed2_api.IManyParamInterfaceEventListener;
 import testbed2.testbed2_api.IManyParamInterface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed2.testbed2_android_service.ManyParamInterfaceServiceAdapter;
 import testbed2.testbed2jniservice.ManyParamInterfaceJniServiceProvider;
 import testbed2.testbed2_android_service.ManyParamInterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class ManyParamInterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static IManyParamInterface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        IManyParamInterface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/testbed2/testbed2jniservice/NestedStruct1InterfaceJniServiceStarter.java
+++ b/goldenmaster/testbed2/testbed2jniservice/NestedStruct1InterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import testbed2.testbed2_api.INestedStruct1InterfaceEventListener;
 import testbed2.testbed2_api.INestedStruct1Interface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed2.testbed2_android_service.NestedStruct1InterfaceServiceAdapter;
 import testbed2.testbed2jniservice.NestedStruct1InterfaceJniServiceProvider;
 import testbed2.testbed2_android_service.NestedStruct1InterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class NestedStruct1InterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static INestedStruct1Interface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        INestedStruct1Interface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/testbed2/testbed2jniservice/NestedStruct2InterfaceJniServiceStarter.java
+++ b/goldenmaster/testbed2/testbed2jniservice/NestedStruct2InterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import testbed2.testbed2_api.INestedStruct2InterfaceEventListener;
 import testbed2.testbed2_api.INestedStruct2Interface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed2.testbed2_android_service.NestedStruct2InterfaceServiceAdapter;
 import testbed2.testbed2jniservice.NestedStruct2InterfaceJniServiceProvider;
 import testbed2.testbed2_android_service.NestedStruct2InterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class NestedStruct2InterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static INestedStruct2Interface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        INestedStruct2Interface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/goldenmaster/testbed2/testbed2jniservice/NestedStruct3InterfaceJniServiceStarter.java
+++ b/goldenmaster/testbed2/testbed2jniservice/NestedStruct3InterfaceJniServiceStarter.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import testbed2.testbed2_api.INestedStruct3InterfaceEventListener;
 import testbed2.testbed2_api.INestedStruct3Interface;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import testbed2.testbed2_android_service.NestedStruct3InterfaceServiceAdapter;
 import testbed2.testbed2jniservice.NestedStruct3InterfaceJniServiceProvider;
 import testbed2.testbed2_android_service.NestedStruct3InterfaceBaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class NestedStruct3InterfaceJniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static INestedStruct3Interface start(Context ctx)
     {
-        return IMPL.start(ctx);
+        INestedStruct3Interface result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 

--- a/rules.yaml
+++ b/rules.yaml
@@ -23,6 +23,10 @@ features:
             target: "{{camel .Module.Name}}_api/src/main/java/{{camel .Module.Name}}/{{camel .Module.Name}}_api/{{Camel .Module.Name}}TestHelper.java"
           - source: "api/remoteoperationexception.java.tpl"
             target: "{{camel .Module.Name}}_api/src/main/java/{{camel .Module.Name}}/{{camel .Module.Name}}_api/RemoteOperationException.java"
+          - source: "api/bindinglifecyclecoordinator.java.tpl"
+            target: "{{camel .Module.Name}}_api/src/main/java/apigear/android/lifecycle/IBindingLifecycleCoordinator.java"
+          - source: "api/bindinglifecycleregistry.java.tpl"
+            target: "{{camel .Module.Name}}_api/src/main/java/apigear/android/lifecycle/BindingLifecycleRegistry.java"
       - match: interface
         prefix: "{{camel .Module.Name}}/{{camel .Module.Name}}_api/src/main/java/{{camel .Module.Name}}/{{camel .Module.Name}}_api/"
         documents:

--- a/templates/api/bindinglifecyclecoordinator.java.tpl
+++ b/templates/api/bindinglifecyclecoordinator.java.tpl
@@ -1,0 +1,27 @@
+package apigear.android.lifecycle;
+
+/**
+ * Interface implemented by the host application to coordinate ServiceConnection
+ * cleanup across generated JNI clients and service starters. A coordinator
+ * is injected via {@link BindingLifecycleRegistry#setCoordinator} at startup;
+ * generated bind code registers a cleanup against it on successful bindService
+ * and unregisters on voluntary unbind.
+ */
+public interface IBindingLifecycleCoordinator
+{
+    /**
+     * Register a cleanup callback to be invoked when the host is about to tear
+     * down the binding's owning Context. The callback should call
+     * {@code Context.unbindService(...)} for the connection it owns.
+     *
+     * <p>Idempotent: implementations should treat duplicate registration of
+     * the same Runnable as a no-op.</p>
+     */
+    void registerCleanup(Runnable cleanup);
+
+    /**
+     * Unregister a previously-registered callback. Called after a voluntary
+     * unbind so the callback isn't run a second time on host shutdown.
+     */
+    void unregisterCleanup(Runnable cleanup);
+}

--- a/templates/api/bindinglifecycleregistry.java.tpl
+++ b/templates/api/bindinglifecycleregistry.java.tpl
@@ -1,0 +1,33 @@
+package apigear.android.lifecycle;
+
+/**
+ * Process-wide injection point for an {@link IBindingLifecycleCoordinator}.
+ * The host application calls {@link #setCoordinator} at startup; generated
+ * JNI bind code calls {@link #get} on every bind/unbind and silently no-ops
+ * when no coordinator has been set (so the generated code is host-agnostic
+ * and safe to run in test environments without a host).
+ */
+public final class BindingLifecycleRegistry
+{
+    private static volatile IBindingLifecycleCoordinator sCoordinator;
+
+    private BindingLifecycleRegistry() {}
+
+    /**
+     * Install the host's coordinator. Typically called once at process startup
+     * from host wiring code (e.g. a UPL-injected static initializer).
+     */
+    public static void setCoordinator(IBindingLifecycleCoordinator coordinator)
+    {
+        sCoordinator = coordinator;
+    }
+
+    /**
+     * Returns the installed coordinator, or {@code null} if the host has not
+     * registered one. Generated code must null-check the result.
+     */
+    public static IBindingLifecycleCoordinator get()
+    {
+        return sCoordinator;
+    }
+}

--- a/templates/jnibridge/client/jnibridgeclient.java.tpl
+++ b/templates/jnibridge/client/jnibridgeclient.java.tpl
@@ -8,6 +8,8 @@ import {{camel .Module.Name}}.{{camel .Module.Name}}_api.RemoteOperationExceptio
 {{- end }}
 
 import {{camel .Module.Name}}.{{camel .Module.Name}}_android_client.{{Camel .Interface.Name }}Client;
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 
 {{- template "importApiWithParcelable" .}}
 import android.content.Context;
@@ -28,6 +30,11 @@ public class {{Camel .Interface.Name}}JniClient extends Abstract{{Camel .Interfa
 
     private static String ModuleName = "{{camel .Module.Name}}.{{camel .Module.Name}}jniservice.{{Camel .Interface.Name}}JniService";
     private String lastServicePackage ="";
+
+    // Stable Runnable reference so coordinator register/unregister see the same
+    // instance. Initialized once per JniClient; method-reference resolution at
+    // field-init time gives a single Runnable bound to this::unbind.
+    private final Runnable mCleanup = this::unbind;
 
     @Override
     public boolean _isReady()
@@ -93,11 +100,25 @@ public class {{Camel .Interface.Name}}JniClient extends Abstract{{Camel .Interfa
 
     public boolean bind(Context ctx, String packageName, String connectionID){
         Log.v(TAG, "natice client: bind " + packageName);
-        return initServiceConnection(ctx, packageName, connectionID);
+        boolean res = initServiceConnection(ctx, packageName, connectionID);
+        if (res)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(mCleanup);
+            }
+        }
+        return res;
     }
 
     public void unbind(){
         Log.v(TAG, "native client: unbind " + lastServicePackage);
+        IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+        if (coordinator != null)
+        {
+            coordinator.unregisterCleanup(mCleanup);
+        }
         if (mMessengerClient != null)
         {
             mMessengerClient.unbindFromService();

--- a/templates/jnibridge/service/jnibridgeservicestarter.java.tpl
+++ b/templates/jnibridge/service/jnibridgeservicestarter.java.tpl
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import {{camel .Module.Name}}.{{camel .Module.Name}}_api.I{{Camel .Interface.Name }}EventListener;
 import {{camel .Module.Name}}.{{camel .Module.Name}}_api.I{{Camel .Interface.Name }};
+import apigear.android.lifecycle.BindingLifecycleRegistry;
+import apigear.android.lifecycle.IBindingLifecycleCoordinator;
 import {{camel .Module.Name}}.{{camel .Module.Name}}_android_service.{{Camel .Interface.Name }}ServiceAdapter;
 import {{camel .Module.Name}}.{{camel .Module.Name}}jniservice.{{Camel .Interface.Name}}JniServiceProvider;
 import {{camel .Module.Name}}.{{camel .Module.Name}}_android_service.{{Camel .Interface.Name }}BaseServiceLifecycleController;
@@ -45,13 +47,42 @@ public class {{Camel .Interface.Name }}JniServiceStarter
         }
     };
 
+    // Stable Runnable reference for coordinator register/unregister. Static
+    // because the starter itself is a static facade over a single IMPL.
+    private static Runnable sCleanup;
+
     public static I{{Camel .Interface.Name }} start(Context ctx)
     {
-        return IMPL.start(ctx);
+        I{{Camel .Interface.Name }} result = IMPL.start(ctx);
+        if (result != null)
+        {
+            // Re-entrant start: drop any previous registration before replacing.
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (sCleanup != null && coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            final Context capturedCtx = ctx;
+            sCleanup = () -> stop(capturedCtx);
+            if (coordinator != null)
+            {
+                coordinator.registerCleanup(sCleanup);
+            }
+        }
+        return result;
     }
 
     public static void stop(Context ctx)
     {
+        if (sCleanup != null)
+        {
+            IBindingLifecycleCoordinator coordinator = BindingLifecycleRegistry.get();
+            if (coordinator != null)
+            {
+                coordinator.unregisterCleanup(sCleanup);
+            }
+            sCleanup = null;
+        }
         IMPL.stop(ctx);
     }
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->


## 📑 Description
<!-- Add a brief description of the pr -->
Adds a host-agnostic Service Provider Interface (SPI_ that generated JNI bind/unbind code can use to  coordinate serviceConnection cleanup with the host application's teardown lifecycle. The need arises when a JNI client binds a Service via a Context whose lifetime is shorter than the binding (e.g. an Android Service Context hosting the engine) -- the host has to drive unbind before that Context is destroyed or Android logs ServiceConnectionLeaked
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->